### PR TITLE
Fix not including debug components

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,2 @@
+# Include debug components
+!src/debug

--- a/web/src/debug/Components.svelte
+++ b/web/src/debug/Components.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import OutlinedInput from "../Components/OutlinedInput.svelte";
+</script>
+
+<main class="p-4">
+  <div class="w-52">
+    <OutlinedInput
+      label="testLabel"
+      id="testId"
+      placeholder="testPlaceholder"
+      assistiveText="your input is shit"
+    />
+  </div>
+</main>


### PR DESCRIPTION
Added custom .gitignore that includes the directory for debug components in web/src/debug.
Debug components or pages are non-navigatable pages for developers to see or debug stuff about the current application. They are still public and can be seen by users if they want.