### PR TITLE
Move authentication to different scope to better separate concerns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-files"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d832782fac6ca7369a70c9ee9a20554623c5e51c76e190ad151780ebea1cf689"
+dependencies = [
+ "actix-http",
+ "actix-service",
+ "actix-utils",
+ "actix-web",
+ "askama_escape",
+ "bitflags",
+ "bytes",
+ "derive_more",
+ "futures-core",
+ "http-range",
+ "log",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "actix-http"
 version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,6 +416,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
+name = "askama_escape"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +466,7 @@ dependencies = [
 name = "auster"
 version = "0.1.0"
 dependencies = [
+ "actix-files",
  "actix-session",
  "actix-web",
  "actix-web-flash-messages",
@@ -1359,6 +1389,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+
+[[package]]
 name = "http-types"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1666,6 +1702,16 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -2886,6 +2932,15 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-bidi"

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -95,12 +95,12 @@ async fn run(
                         web::scope("/rooms")
                             .wrap(from_fn(reject_anonymous_users))
                             .route("/", web::get().to(health_check)),
-                    )
-                    .service(
-                        web::scope("/authentication")
-                            .route("/signin", web::post().to(signin))
-                            .route("/signout", web::post().to(signout)),
                     ),
+            )
+            .service(
+                web::scope("/authentication")
+                    .route("/signin", web::post().to(signin))
+                    .route("/signout", web::post().to(signout)),
             )
             .route("/health", web::get().to(health_check))
             .route("/ready", web::get().to(ready_check))


### PR DESCRIPTION
Move authentication out of "API" scope for the following reasons:
* Authentication and authorization is not RESTful (from my limited understanding of REST)
  * REST is supposed to be stateless and authentication/authorization is by nature stateful
  * The statelessness enables easier horizontal scaling (not that we need that anytime soon but yeah)
* It helps us separating the concerns of authentication and the API. We might thank ourselves when moving to external authentication or changing the authentication system.

Downsides:
* The "/api" route helped clearly separating what is backend and what is a frontend route. A "/authentication" might muddy the water

This is in preparation for #34 where I plan to add server side UI and the "/authentication" scope behaves kind of like an authentication server